### PR TITLE
Fix mptf cross listing related crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -217,3 +217,7 @@
 ## [2.0.8] - 2020-10-17
 ### Added
 - Scream Fortress 2020 effects.
+
+## [2.0.9] - 2020-11-30
+### Fixed
+- Crash because of marketplace cross listings on classifieds

--- a/src/deps.js
+++ b/src/deps.js
@@ -150,6 +150,11 @@ const Utils = {
      * @returns {(Object|null)} Object of currencies if string is valid
      */
     stringToCurrencies: function(string) {
+        // mptf cross listing has no listing_price
+        if (!string) {
+            return null;
+        }
+        
         const prices = string.split(',');
         const currencies = {};
         const currencyNames = {

--- a/src/js/backpack.tf.classifieds.js
+++ b/src/js/backpack.tf.classifieds.js
@@ -10,16 +10,8 @@ function({ Utils }) {
         const href = offerButtonEl.getAttribute('href');
         const {
             listing_intent,
-            listing_price,
-            listing_mp_price
+            listing_price
         } = itemEl.dataset;
-
-        // mp listing, no currencies
-        if (listing_mp_price) {
-            // continue to avoid crash
-            return;
-        }
-        
         const currencies = Utils.stringToCurrencies(listing_price);
         
         // no currencies

--- a/src/js/backpack.tf.classifieds.js
+++ b/src/js/backpack.tf.classifieds.js
@@ -10,8 +10,16 @@ function({ Utils }) {
         const href = offerButtonEl.getAttribute('href');
         const {
             listing_intent,
-            listing_price
+            listing_price,
+            listing_mp_price
         } = itemEl.dataset;
+
+        // mp listing, no currencies
+        if (listing_mp_price) {
+            // continue to avoid crash
+            return;
+        }
+        
         const currencies = Utils.stringToCurrencies(listing_price);
         
         // no currencies

--- a/src/meta.js
+++ b/src/meta.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name        Steam Trade Offer Enhancer
 // @description Browser script to enhance Steam trade offers.
-// @version     2.0.8
+// @version     2.0.9
 // @author      Julia
 // @namespace   http://steamcommunity.com/profiles/76561198080179568/
 // @updateURL   https://github.com/juliarose/steam-trade-offer-enhancer/raw/master/steam.trade.offer.enhancer.meta.js

--- a/steam.trade.offer.enhancer.meta.js
+++ b/steam.trade.offer.enhancer.meta.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name        Steam Trade Offer Enhancer
 // @description Browser script to enhance Steam trade offers.
-// @version     2.0.8
+// @version     2.0.9
 // @author      Julia
 // @namespace   http://steamcommunity.com/profiles/76561198080179568/
 // @updateURL   https://github.com/juliarose/steam-trade-offer-enhancer/raw/master/steam.trade.offer.enhancer.meta.js

--- a/steam.trade.offer.enhancer.user.js
+++ b/steam.trade.offer.enhancer.user.js
@@ -40,16 +40,8 @@
                     const href = offerButtonEl.getAttribute('href');
                     const {
                         listing_intent,
-                        listing_price,
-                        listing_mp_price
+                        listing_price
                     } = itemEl.dataset;
-
-                    // mp listing, no currencies
-                    if (listing_mp_price) {
-                        // continue to avoid crash
-                        return;
-                    }
-
                     const currencies = Utils.stringToCurrencies(listing_price);
                     
                     // no currencies
@@ -2974,6 +2966,11 @@
                  * @returns {(Object|null)} Object of currencies if string is valid
                  */
                 stringToCurrencies: function(string) {
+                    // mptf cross listing has no listing_price
+                    if (!string) {
+                        return null;
+                    }
+                    
                     const prices = string.split(',');
                     const currencies = {};
                     const currencyNames = {

--- a/steam.trade.offer.enhancer.user.js
+++ b/steam.trade.offer.enhancer.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name        Steam Trade Offer Enhancer
 // @description Browser script to enhance Steam trade offers.
-// @version     2.0.8
+// @version     2.0.9
 // @author      Julia
 // @namespace   http://steamcommunity.com/profiles/76561198080179568/
 // @updateURL   https://github.com/juliarose/steam-trade-offer-enhancer/raw/master/steam.trade.offer.enhancer.meta.js
@@ -40,8 +40,16 @@
                     const href = offerButtonEl.getAttribute('href');
                     const {
                         listing_intent,
-                        listing_price
+                        listing_price,
+                        listing_mp_price
                     } = itemEl.dataset;
+
+                    // mp listing, no currencies
+                    if (listing_mp_price) {
+                        // continue to avoid crash
+                        return;
+                    }
+
                     const currencies = Utils.stringToCurrencies(listing_price);
                     
                     // no currencies
@@ -2813,7 +2821,7 @@
     (function() {
         const DEPS = (function() {
             // current version number of script
-            const VERSION = '2.0.8';
+            const VERSION = '2.0.9';
             // our window object for accessing globals
             const WINDOW = unsafeWindow;
             // dependencies to provide to each page script    


### PR DESCRIPTION
Whenever a page had a mptf cross listing (and therefor no listing_price in the dataset) the script would crash trying to get `currencyNames[match[2]]` and the query string for the trade offer link wouldn't be modified