### PR TITLE
Fix dead zone in item boxes

### DIFF
--- a/src/css/steamcommunity.com.market.listings.440.css
+++ b/src/css/steamcommunity.com.market.listings.440.css
@@ -45,6 +45,7 @@
     z-index: 1;
     line-height: 1;
     position: absolute;
+    pointer-events: none;
 }
 
 .icons > * {
@@ -53,6 +54,7 @@
 
 .icons {
     position: absolute;
+    pointer-events: none;
     bottom: 4%;
     left: 4%;
     width: 92%;

--- a/src/css/steamcommunity.com.profiles.css
+++ b/src/css/steamcommunity.com.profiles.css
@@ -45,6 +45,7 @@
     z-index: 1;
     line-height: 1;
     position: absolute;
+    pointer-events: none;
 }
 
 .icons > * {
@@ -53,6 +54,7 @@
 
 .icons {
     position: absolute;
+    pointer-events: none;
     bottom: 4%;
     left: 4%;
     width: 92%;

--- a/src/css/steamcommunity.com.profiles.inventory.css
+++ b/src/css/steamcommunity.com.profiles.inventory.css
@@ -45,6 +45,7 @@
     z-index: 1;
     line-height: 1;
     position: absolute;
+    pointer-events: none;
 }
 
 .icons > * {
@@ -53,6 +54,7 @@
 
 .icons {
     position: absolute;
+    pointer-events: none;
     bottom: 4%;
     left: 4%;
     width: 92%;

--- a/src/css/steamcommunity.com.profiles.tradeoffers.css
+++ b/src/css/steamcommunity.com.profiles.tradeoffers.css
@@ -123,6 +123,7 @@
     z-index: 1;
     line-height: 1;
     position: absolute;
+    pointer-events: none;
 }
 
 .icons > * {
@@ -131,6 +132,7 @@
 
 .icons {
     position: absolute;
+    pointer-events: none;
     bottom: 4%;
     left: 4%;
     width: 92%;

--- a/src/css/steamcommunity.com.tradeoffer.css
+++ b/src/css/steamcommunity.com.tradeoffer.css
@@ -120,6 +120,7 @@
     z-index: 1;
     line-height: 1;
     position: absolute;
+    pointer-events: none;
 }
 
 .icons > * {
@@ -128,6 +129,7 @@
 
 .icons {
     position: absolute;
+    pointer-events: none;
     bottom: 4%;
     left: 4%;
     width: 92%;

--- a/steam.trade.offer.enhancer.user.js
+++ b/steam.trade.offer.enhancer.user.js
@@ -518,6 +518,7 @@ const scripts = [
                 z-index: 1;
                 line-height: 1;
                 position: absolute;
+                pointer-events: none;
             }
             
             .icons > * {
@@ -526,6 +527,7 @@ const scripts = [
             
             .icons {
                 position: absolute;
+                pointer-events: none;
                 bottom: 4%;
                 left: 4%;
                 width: 92%;
@@ -686,6 +688,7 @@ const scripts = [
                 z-index: 1;
                 line-height: 1;
                 position: absolute;
+                pointer-events: none;
             }
             
             .icons > * {
@@ -694,6 +697,7 @@ const scripts = [
             
             .icons {
                 position: absolute;
+                pointer-events: none;
                 bottom: 4%;
                 left: 4%;
                 width: 92%;
@@ -852,6 +856,7 @@ const scripts = [
                 z-index: 1;
                 line-height: 1;
                 position: absolute;
+                pointer-events: none;
             }
             
             .icons > * {
@@ -860,6 +865,7 @@ const scripts = [
             
             .icons {
                 position: absolute;
+                pointer-events: none;
                 bottom: 4%;
                 left: 4%;
                 width: 92%;
@@ -1007,6 +1013,7 @@ const scripts = [
                 z-index: 1;
                 line-height: 1;
                 position: absolute;
+                pointer-events: none;
             }
             
             .icons > * {
@@ -1015,6 +1022,7 @@ const scripts = [
             
             .icons {
                 position: absolute;
+                pointer-events: none;
                 bottom: 4%;
                 left: 4%;
                 width: 92%;
@@ -1469,6 +1477,7 @@ const scripts = [
                 z-index: 1;
                 line-height: 1;
                 position: absolute;
+                pointer-events: none;
             }
             
             .icons > * {
@@ -1477,6 +1486,7 @@ const scripts = [
             
             .icons {
                 position: absolute;
+                pointer-events: none;
                 bottom: 4%;
                 left: 4%;
                 width: 92%;


### PR DESCRIPTION
Adds `pointer-events: none;` to the divs containing the low craft number and the strange part/killstreak icons. 

Previously, clicking in the area shown below would do nothing because the divs would prevent you from interacting with the item element.
![image](https://github.com/user-attachments/assets/4d05c5ba-f3b3-4382-8861-6bb3c093c46c)
