### PR TITLE
Update particle list, update particle image url, fix steam inventory url trailing slash

### DIFF
--- a/src/deps.js
+++ b/src/deps.js
@@ -387,7 +387,7 @@ const shared = {
                     // construct icon for strange parts
                     const partsEl = document.createElement('img');
                     
-                    partsEl.setAttribute('src', 'https://tf2.kresenko.com/assets/wrench.png');
+                    partsEl.setAttribute('src', 'https://itempedia.tf/assets/wrench.png');
                     partsEl.classList.add('parts');
                     
                     // add it to the icons element
@@ -398,7 +398,7 @@ const shared = {
                     // construct icon for killstreak
                     const ksEl = document.createElement('img');
                     
-                    ksEl.setAttribute('src', 'https://tf2.kresenko.com/assets/icon-ks.png');
+                    ksEl.setAttribute('src', 'https://itempedia.tf/assets/icon-ks.png');
                     ksEl.classList.add('ks');
                     
                     // add it to the icons element
@@ -744,6 +744,20 @@ const shared = {
                 'Shining Bokeh': 370,
                 'Playful Aurora': 371,
                 'Frisky Morning': 372,
+                'Drunkard': 373,
+                'Blades of Betrayal': 374,
+                'Death\'s Daggers': 376,
+                'Fully Charged': 377,
+                'Overcharged': 379,
+                'Piercing Headache': 380,
+                'Decimating Wind': 381,
+                'Ocean Swirl': 382,
+                'Toxic Swirl': 384,
+                'Candle Flame': 385,
+                'Sizzling Aroma': 387,
+                'Toxic Aroma': 389,
+                'Current Conductor': 390,
+                'Sandy': 392,
                 'Hot': 701,
                 'Isotope': 702,
                 'Cool': 703,
@@ -909,6 +923,20 @@ const shared = {
                 'Award Winning': 3190,
                 'Operatic Triumph': 3192,
                 'Tangled Lights': 3193,
+                'Seamine': 3194,
+                'Iconic Outline': 3196,
+                'Subtle Silhouette': 3198,
+                'Ocean Reef': 3199,
+                'Lost Signal': 3200,
+                'Summer Wave': 3201,
+                'Shark Attack': 3202,
+                'Hazardous Gas': 3203,
+                'Phantasmal Fog': 3204,
+                'Split Malice': 3206,
+                'Void Crawlers': 3208,
+                'Fossil Fueled': 3209,
+                'Tar Pit': 3210,
+                'Morbidly Beast': 3211,
             },
             /**
              * Includes effect image in element.
@@ -935,7 +963,7 @@ const shared = {
              * @returns {string} URL string
              */
             getEffectURL(value) {
-                return `https://tf2.kresenko.com/assets/particles/${value}_94x94.png`;
+                return `https://itempedia.tf/assets/particles/${value}_94x94.png`;
             }
         }
     }

--- a/src/js/steamcommunity.com.profiles.inventory.js
+++ b/src/js/steamcommunity.com.profiles.inventory.js
@@ -1,4 +1,4 @@
-// @include /^https?:\/\/steamcommunity\.com\/(?:id|profiles)\/[^\/]+\/inventory(?:[/#].*|$)/
+// @include /^https?:\/\/steamcommunity\.com\/(?:id|profiles)\/[^\/]+\/inventory(?:#.*)?(?:\/)?$/
 function main({ WINDOW, shared }) {
     const dom = {
         inventory: document.getElementById('inventories'),

--- a/steam.trade.offer.enhancer.user.js
+++ b/steam.trade.offer.enhancer.user.js
@@ -14,7 +14,7 @@
 // @include     /^https?:\/\/(.*\.)?backpack\.tf(:\\d+)?\/(stats|classifieds).*/
 // @include     /^https?:\/\/(.*\.)?backpack\.tf(:\d+)?\/(?:id|profiles)\/.*/
 // @include     /^https?:\/\/steamcommunity\.com\/market\/listings\/440\/.*/
-// @include     /^https?:\/\/steamcommunity\.com\/(?:id|profiles)\/[^\/]+\/inventory(?:[/#].*|$)/
+// @include     /^https?:\/\/steamcommunity\.com\/(?:id|profiles)\/[^\/]+\/inventory(?:#.*)?(?:\/)?$/
 // @include     /^https?:\/\/steamcommunity\.com\/(?:id|profiles)\/[^\/]+(\/$|\?|$)/
 // @include     /^https?:\/\/steamcommunity\.com\/(?:id|profiles)\/.*\/tradeoffers/
 // @include     /^https?:\/\/steamcommunity\.com\/tradeoffer.*/
@@ -3990,7 +3990,7 @@ const DEPS = (function() {
                         // construct icon for strange parts
                         const partsEl = document.createElement('img');
                         
-                        partsEl.setAttribute('src', 'https://tf2.kresenko.com/assets/wrench.png');
+                        partsEl.setAttribute('src', 'https://itempedia.tf/assets/wrench.png');
                         partsEl.classList.add('parts');
                         
                         // add it to the icons element
@@ -4001,7 +4001,7 @@ const DEPS = (function() {
                         // construct icon for killstreak
                         const ksEl = document.createElement('img');
                         
-                        ksEl.setAttribute('src', 'https://tf2.kresenko.com/assets/icon-ks.png');
+                        ksEl.setAttribute('src', 'https://itempedia.tf/assets/icon-ks.png');
                         ksEl.classList.add('ks');
                         
                         // add it to the icons element
@@ -4347,6 +4347,20 @@ const DEPS = (function() {
                     'Shining Bokeh': 370,
                     'Playful Aurora': 371,
                     'Frisky Morning': 372,
+                    'Drunkard': 373,
+                    'Blades of Betrayal': 374,
+                    'Death\'s Daggers': 376,
+                    'Fully Charged': 377,
+                    'Overcharged': 379,
+                    'Piercing Headache': 380,
+                    'Decimating Wind': 381,
+                    'Ocean Swirl': 382,
+                    'Toxic Swirl': 384,
+                    'Candle Flame': 385,
+                    'Sizzling Aroma': 387,
+                    'Toxic Aroma': 389,
+                    'Current Conductor': 390,
+                    'Sandy': 392,
                     'Hot': 701,
                     'Isotope': 702,
                     'Cool': 703,
@@ -4512,6 +4526,20 @@ const DEPS = (function() {
                     'Award Winning': 3190,
                     'Operatic Triumph': 3192,
                     'Tangled Lights': 3193,
+                    'Seamine': 3194,
+                    'Iconic Outline': 3196,
+                    'Subtle Silhouette': 3198,
+                    'Ocean Reef': 3199,
+                    'Lost Signal': 3200,
+                    'Summer Wave': 3201,
+                    'Shark Attack': 3202,
+                    'Hazardous Gas': 3203,
+                    'Phantasmal Fog': 3204,
+                    'Split Malice': 3206,
+                    'Void Crawlers': 3208,
+                    'Fossil Fueled': 3209,
+                    'Tar Pit': 3210,
+                    'Morbidly Beast': 3211,
                 },
                 /**
                  * Includes effect image in element.
@@ -4538,7 +4566,7 @@ const DEPS = (function() {
                  * @returns {string} URL string
                  */
                 getEffectURL(value) {
-                    return `https://tf2.kresenko.com/assets/particles/${value}_94x94.png`;
+                    return `https://itempedia.tf/assets/particles/${value}_94x94.png`;
                 }
             }
         }


### PR DESCRIPTION
## Improvements

### Update particle list

Updated to the latest particle effect list. Source https://itempedia.tf/effects

### Update particle image url

Since the project migrated the domain, url for the particle images was updated

### Fix steam inventory url trailing slash

Before, the script would not match steam profile when there is a trailing slash (eg. https://steamcommunity.com/id/kresenko)
Now, the script will optionally match the trailing slash (https://steamcommunity.com/id/kresenko/)