### PR TITLE
Minor UI fixes

### DIFF
--- a/src/css/steamcommunity.com.market.listings.440.css
+++ b/src/css/steamcommunity.com.market.listings.440.css
@@ -33,6 +33,7 @@
 .icons img.ks {
     width: 14px;
     height: 15px;
+    padding-top: 5px;
 }
 
 .lowcraft {

--- a/src/css/steamcommunity.com.profiles.css
+++ b/src/css/steamcommunity.com.profiles.css
@@ -11,6 +11,7 @@
 .strange:before {
     content: " ";
     position: absolute;
+    pointer-events: none;
     z-index: 1;
     top: 2px;
     left: 2px;
@@ -33,6 +34,7 @@
 .icons img.ks {
     width: 14px;
     height: 15px;
+    padding-top: 5px;
 }
 
 .lowcraft {

--- a/src/css/steamcommunity.com.profiles.inventory.css
+++ b/src/css/steamcommunity.com.profiles.inventory.css
@@ -33,6 +33,7 @@
 .icons img.ks {
     width: 14px;
     height: 15px;
+    padding-top: 5px;
 }
 
 .lowcraft {

--- a/src/css/steamcommunity.com.profiles.tradeoffers.css
+++ b/src/css/steamcommunity.com.profiles.tradeoffers.css
@@ -111,6 +111,7 @@
 .icons img.ks {
     width: 14px;
     height: 15px;
+    padding-top: 5px;
 }
 
 .lowcraft {

--- a/src/css/steamcommunity.com.tradeoffer.css
+++ b/src/css/steamcommunity.com.tradeoffer.css
@@ -108,6 +108,7 @@
 .icons img.ks {
     width: 14px;
     height: 15px;
+    padding-top: 5px;
 }
 
 .lowcraft {

--- a/steam.trade.offer.enhancer.user.js
+++ b/steam.trade.offer.enhancer.user.js
@@ -506,6 +506,7 @@ const scripts = [
             .icons img.ks {
                 width: 14px;
                 height: 15px;
+                padding-top: 5px;
             }
             
             .lowcraft {
@@ -676,6 +677,7 @@ const scripts = [
             .icons img.ks {
                 width: 14px;
                 height: 15px;
+                padding-top: 5px;
             }
             
             .lowcraft {
@@ -822,6 +824,7 @@ const scripts = [
             .strange:before {
                 content: " ";
                 position: absolute;
+                pointer-events: none;
                 z-index: 1;
                 top: 2px;
                 left: 2px;
@@ -844,6 +847,7 @@ const scripts = [
             .icons img.ks {
                 width: 14px;
                 height: 15px;
+                padding-top: 5px;
             }
             
             .lowcraft {
@@ -1001,6 +1005,7 @@ const scripts = [
             .icons img.ks {
                 width: 14px;
                 height: 15px;
+                padding-top: 5px;
             }
             
             .lowcraft {
@@ -1465,6 +1470,7 @@ const scripts = [
             .icons img.ks {
                 width: 14px;
                 height: 15px;
+                padding-top: 5px;
             }
             
             .lowcraft {


### PR DESCRIPTION
This PR fixes a dead zone with items that have the strange elevated quality (e.g. Strange Unusual), specifically on profile pages.
<img width="480" height="164" alt="librewolf_uOz51LXx8R" src="https://github.com/user-attachments/assets/6998ce18-5a6f-4ae0-8e74-bae1468843e0" />

Additionally, a padding has been added to the killstreak icons to match the height of the other icons to fix their misalignment when they're not alongside other icons.

**Before:**
<img width="418" height="418" alt="image" src="https://github.com/user-attachments/assets/0f0ae7b2-08c1-4d54-8f30-b26ca8c57173" />

**After:**
<img width="418" height="418" alt="image" src="https://github.com/user-attachments/assets/95443c4e-cf97-469f-bd96-d1a02ef78359" />
